### PR TITLE
Fix Nix Sandbox Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ name: Test
 
 jobs:
   build:
-    name: Test
+    name: Test/Cargo
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -49,7 +49,23 @@ jobs:
         run: |
           cargo install cargo-rdme
           cargo rdme --check
-
+  nix:
+    name: Test/Nix (${{ matrix.system.nix }})
+    strategy:
+      matrix:
+        system:
+          [
+            { gha: ubuntu-latest, nix: "x86_64-linux" },
+            { gha: macos-13, nix: "x86_64-darwin" },
+            { gha: macos-14, nix: "aarch64-darwin" },
+          ]
+    runs-on: ${{ matrix.system.gha }}
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: nix build
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719426051,
-        "narHash": "sha256-yJL9VYQhaRM7xs0M867ZFxwaONB9T2Q4LnGo1WovuR4=",
+        "lastModified": 1717144377,
+        "narHash": "sha256-F/TKWETwB5RaR8owkPPi+SPJh83AQsm6KrQAlJ8v/uA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "89c49874fb15f4124bf71ca5f42a04f2ee5825fd",
+        "rev": "805a384895c696f802a9bf5bf4720f37385df547",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,12 +21,31 @@
       rustPkgs = pkgs.rustBuilder.makePackageSet {
         rustVersion = "1.75.0";
         # You can regenerate Cargo.nix using this command:
-        #   nix run github:cargo2nix/cargo2nix 
+        #   nix run github:cargo2nix/cargo2nix
         packageFun = import ./Cargo.nix;
+
+        packageOverrides = pkgs:
+          pkgs.rustBuilder.overrides.all
+          ++ [
+            (pkgs.rustBuilder.rustLib.makeOverride {
+              name = "rustsat-kissat";
+              overrideAttrs = {
+                buildInputs = [
+                  pkgs.kissat
+                ];
+                patches = [
+                  ./nix/patches/rustsat-kissat.patch
+                ];
+                NIX_KISSAT_DIR="${pkgs.kissat.lib}";
+              };
+            })
+          ];
       };
-    in rec {
-      quaigh = rustPkgs.workspace.quaigh {};
-      default = quaigh;
-    });
+      self = {
+        quaigh = rustPkgs.workspace.quaigh {};
+        default = self.quaigh;
+      };
+    in
+      self);
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
               overrideAttrs = {
                 buildInputs = [
                   pkgs.kissat
+                ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+                  pkgs.openssl
                 ];
                 patches = [
                   ./nix/patches/rustsat-kissat.patch

--- a/nix/patches/rustsat-kissat.patch
+++ b/nix/patches/rustsat-kissat.patch
@@ -1,0 +1,45 @@
+diff --git a/build.rs b/build.rs
+index 3199616..5e6777b 100644
+--- a/build.rs
++++ b/build.rs
+@@ -9,38 +9,12 @@ use std::{
+ };
+ 
+ fn main() {
+-    if std::env::var("DOCS_RS").is_ok() {
+-        // don't build c library on docs.rs due to network restrictions
+-        return;
+-    }
+-
+-    // Select commit based on features. If conflict, always choose newest release
+-    let tag = if cfg!(feature = "v3-1-1") {
+-        "refs/tags/rel-3.1.1"
+-    } else if cfg!(feature = "v3-1-0") {
+-        "refs/tags/rel-3.1.0"
+-    } else if cfg!(feature = "v3-0-0") {
+-        "refs/tags/rel-3.0.0"
+-    } else if cfg!(feature = "sc2022-light") {
+-        "refs/tags/sc2022-light"
+-    } else if cfg!(feature = "sc2022-hyper") {
+-        "refs/tags/sc2022-hyper"
+-    } else if cfg!(feature = "sc2022-bulky") {
+-        "refs/tags/sc2022-bulky"
+-    } else {
+-        // default to newest version
+-        "refs/tags/rel-3.1.1"
+-    };
+-
+-    // Build C library
+-    // Full commit hash needs to be provided
+-    build("https://github.com/arminbiere/kissat.git", "master", tag);
+-
+-    let out_dir = env::var("OUT_DIR").unwrap();
++    let out_dir = env::var("NIX_KISSAT_DIR").unwrap();
+ 
+     // Built solver is in out_dir
+     println!("cargo:rustc-link-search={}", out_dir);
+     println!("cargo:rustc-link-search={}/lib", out_dir);
++    println!("cargo:rustc-link-lib=kissat");
+ }
+ 
+ fn build(repo: &str, branch: &str, reference: &str) {


### PR DESCRIPTION
Patches the `rustsat-kissat` crate so it no longer requires network access to be built, which will not work unless the Nix sandbox is disabled (which it is by default on macOS for performance reasons-- the reason this wasn't initially caught.)

Tested builds on aarch64-darwin, x86_64-darwin, aarch64-linux and x86_64-linux.

Extremely sorry for not catching this in the original PR.